### PR TITLE
TinyMCE integration improvements

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -1067,7 +1067,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 						'use_rest_api'                 => intval( self::use_rest_api() ),
 						'endpoint_url'                 => self::get_entries_endpoint_url(),
 						'backend_liveblogging'         => apply_filters( 'liveblog_back_end_liveblogging', false ),
-						'use_tinymce_editor'           => apply_filters( 'liveblog_use_tinymce_editor', false ),
+						'usetinymce'                   => apply_filters( 'liveblog_use_tinymce_editor', false ),
 						'is_admin'                     => is_admin(),
 
 						'features'                     => WPCOM_Liveblog_Entry_Extend::get_enabled_features(),

--- a/liveblog.php
+++ b/liveblog.php
@@ -1067,6 +1067,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 						'use_rest_api'                 => intval( self::use_rest_api() ),
 						'endpoint_url'                 => self::get_entries_endpoint_url(),
 						'backend_liveblogging'         => apply_filters( 'liveblog_back_end_liveblogging', false ),
+						'use_tinymce_editor'           => apply_filters( 'liveblog_use_tinymce_editor', false ),
 						'is_admin'                     => is_admin(),
 
 						'features'                     => WPCOM_Liveblog_Entry_Extend::get_enabled_features(),

--- a/src/react/Editor/Editor.js
+++ b/src/react/Editor/Editor.js
@@ -325,6 +325,7 @@ class EditorWrapper extends Component {
       defaultImageSize,
       usetinymce,
       editorContainer,
+      clearAuthors,
     } = this.props;
 
     // Admin liveblogging uses TinyMCE.
@@ -332,6 +333,7 @@ class EditorWrapper extends Component {
       return <TinyMCEEditor
         editorState={editorState}
         editorContainer={editorContainer}
+        clearAuthors={clearAuthors}
       />;
     }
 
@@ -402,6 +404,7 @@ EditorWrapper.propTypes = {
   backend: PropTypes.string,
   usetinymce: PropTypes.string,
   editorContainer: PropTypes.object,
+  clearAuthors: PropTypes.func,
 };
 
 export default EditorWrapper;

--- a/src/react/Editor/Editor.js
+++ b/src/react/Editor/Editor.js
@@ -324,11 +324,12 @@ class EditorWrapper extends Component {
       handleImageUpload,
       defaultImageSize,
       backend,
+      use_tinymce_editor,
       editorContainer,
     } = this.props;
 
     // Admin liveblogging uses TinyMCE.
-    if (backend === '1') {
+    if (use_tinymce_editor === '1') {
       return <TinyMCEEditor
         editorState={editorState}
         editorContainer={editorContainer}
@@ -400,6 +401,7 @@ EditorWrapper.propTypes = {
   setReadOnly: PropTypes.func,
   defaultImageSize: PropTypes.string,
   backend: PropTypes.string,
+  use_tinymce_editor: PropTypes.string,
   editorContainer: PropTypes.object,
 };
 

--- a/src/react/Editor/Editor.js
+++ b/src/react/Editor/Editor.js
@@ -323,13 +323,12 @@ class EditorWrapper extends Component {
       setReadOnly,
       handleImageUpload,
       defaultImageSize,
-      backend,
-      use_tinymce_editor,
+      usetinymce,
       editorContainer,
     } = this.props;
 
     // Admin liveblogging uses TinyMCE.
-    if (use_tinymce_editor === '1') {
+    if (usetinymce === '1') {
       return <TinyMCEEditor
         editorState={editorState}
         editorContainer={editorContainer}
@@ -401,7 +400,7 @@ EditorWrapper.propTypes = {
   setReadOnly: PropTypes.func,
   defaultImageSize: PropTypes.string,
   backend: PropTypes.string,
-  use_tinymce_editor: PropTypes.string,
+  usetinymce: PropTypes.string,
   editorContainer: PropTypes.object,
 };
 

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -4,6 +4,16 @@
 
 import React, { Component } from 'react';
 
+export const getTinyMCEContent = () => {
+  const currentEditor = tinymce.activeEditor;
+  console.log(currentEditor);
+  const $textField = jQuery(`#${currentEditor.id}`);
+  if ($textField.is(':visible')) {
+    return $textField.val();
+  }
+
+  return currentEditor ? currentEditor.getContent() : '';
+};
 class TinyMCEEditor extends Component {
   constructor(props) {
     super(props);

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -50,7 +50,7 @@ class TinyMCEEditor extends Component {
           }
         });
         const stateContent = this.props.editorContainer.getContent();
-        if (stateContent) {
+        if (stateContent && '' !== stateContent && '<p></p>' !== stateContent) {
           tinymce.activeEditor.setContent(stateContent);
         }
       }, 500);
@@ -62,8 +62,5 @@ class TinyMCEEditor extends Component {
     return <textarea className="liveblog-editor-textarea" id={this.containerId} />;
   }
 }
-
-TinyMCEEditor.propTypes = {
-};
 
 export default TinyMCEEditor;

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -1,4 +1,4 @@
-/* global wp,  tinymce, _, jQuery */
+/* global wp,  tinymce, jQuery */
 /* eslint-disable no-return-assign */
 /* eslint-disable react/prop-types */
 
@@ -31,7 +31,7 @@ class TinyMCEEditor extends Component {
     setTimeout(() => {
       setTimeout(() => {
         const stateContent = this.props.editorContainer.getContent();
-        if (stateContent && '' !== stateContent && '<p></p>' !== stateContent) {
+        if (stateContent && stateContent !== '' && stateContent !== '<p></p>') {
           tinymce.activeEditor.setContent(stateContent);
         }
       }, 500);

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -20,10 +20,18 @@ export const clearTinyMCEContent = () => {
   $textField.empty();
   currentEditor.setContent('');
 };
+
+export const clearAuthors = () => {
+  if (tinymce.activeEditor.clearAuthors) {
+    tinymce.activeEditor.clearAuthors();
+  }
+};
+
+
 class TinyMCEEditor extends Component {
   constructor(props) {
     super(props);
-    this.containerId = `live-editor-${Math.floor(Math.random() * 10000)}`;
+    this.containerId = `live-editor-${Math.floor(Math.random() * 100000)}`;
     this.editorSettings = {
       tinymce: {
         wpautop: true,
@@ -38,6 +46,7 @@ class TinyMCEEditor extends Component {
     setTimeout(() => {
       setTimeout(() => {
         const stateContent = this.props.editorContainer.getContent();
+        tinymce.activeEditor.clearAuthors = this.props.clearAuthors;
         if (stateContent && stateContent !== '' && stateContent !== '<p></p>') {
           tinymce.activeEditor.setContent(stateContent);
         }

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 
 export const getTinyMCEContent = () => {
   const currentEditor = tinymce.activeEditor;
-  console.log(currentEditor);
   const $textField = jQuery(`#${currentEditor.id}`);
   if ($textField.is(':visible')) {
     return $textField.val();
@@ -31,24 +30,6 @@ class TinyMCEEditor extends Component {
     };
     setTimeout(() => {
       setTimeout(() => {
-        const currentEditor = _.findWhere(tinymce.editors, { id: this.containerId });
-        const $textField = jQuery(`#${this.containerId}`);
-        currentEditor.on('change', () => {
-          const content = currentEditor.getContent();
-          if (content) {
-            this.props.editorContainer.setState({ rawText: content }, () => {
-              this.props.editorContainer.syncRawTextToEditorState();
-            });
-          }
-        });
-        $textField.on('change blur', () => {
-          const content = $textField.val();
-          if (content) {
-            this.props.editorContainer.setState({ rawText: content }, () => {
-              this.props.editorContainer.syncRawTextToEditorState();
-            });
-          }
-        });
         const stateContent = this.props.editorContainer.getContent();
         if (stateContent && '' !== stateContent && '<p></p>' !== stateContent) {
           tinymce.activeEditor.setContent(stateContent);

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -13,6 +13,13 @@ export const getTinyMCEContent = () => {
 
   return currentEditor ? currentEditor.getContent() : '';
 };
+
+export const clearTinyMCEContent = () => {
+  const currentEditor = tinymce.activeEditor;
+  const $textField = jQuery(`#${currentEditor.id}`);
+  $textField.empty();
+  currentEditor.setContent('');
+};
 class TinyMCEEditor extends Component {
   constructor(props) {
     super(props);

--- a/src/react/containers/AppContainer.js
+++ b/src/react/containers/AppContainer.js
@@ -39,6 +39,7 @@ class AppContainer extends Component {
         <EditorContainer
           isEditing={false}
           backend={config.backend_liveblogging}
+          use_tinymce_editor={config.use_tinymce_editor}
         />}
         <UpdateButton polling={polling} click={() => mergePolling()} />
         <Entries loading={loading} entries={entries} config={config}/>

--- a/src/react/containers/AppContainer.js
+++ b/src/react/containers/AppContainer.js
@@ -39,7 +39,7 @@ class AppContainer extends Component {
         <EditorContainer
           isEditing={false}
           backend={config.backend_liveblogging}
-          use_tinymce_editor={config.use_tinymce_editor}
+          usetinymce={config.usetinymce}
         />}
         <UpdateButton polling={polling} click={() => mergePolling()} />
         <Entries loading={loading} entries={entries} config={config}/>

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -59,6 +59,10 @@ class EditorContainer extends Component {
       editorState,
       rawText: html(convertToHTML(editorState.getCurrentContent())),
     });
+
+    this.clearAuthors = () => this.setState({
+      authors: false,
+    });
   }
 
   setReadOnly(state) {
@@ -280,6 +284,7 @@ class EditorContainer extends Component {
             setReadOnly={this.setReadOnly.bind(this)}
             defaultImageSize={config.default_image_size}
             usetinymce={config.usetinymce}
+            clearAuthors={this.clearAuthors}
           />
         }
         {

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -279,7 +279,7 @@ class EditorContainer extends Component {
             readOnly={readOnly}
             setReadOnly={this.setReadOnly.bind(this)}
             defaultImageSize={config.default_image_size}
-            use_tinymce_editor={config.use_tinymce_editor}
+            usetinymce={config.usetinymce}
           />
         }
         {

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -308,7 +308,7 @@ class EditorContainer extends Component {
           cache={false}
         />
         <button className="button button-primary button-large liveblog-btn liveblog-publish-btn" onClick={this.publish.bind(this)}>
-          {'Post Update'}
+          {isEditing ? 'Save' : 'Post Update'}
         </button>
         <input type="hidden" id="liveblog_editor_authors" value={authorIds.join(',')} />
       </div>

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -279,7 +279,7 @@ class EditorContainer extends Component {
             readOnly={readOnly}
             setReadOnly={this.setReadOnly.bind(this)}
             defaultImageSize={config.default_image_size}
-            backend={backend}
+            use_tinymce_editor={config.use_tinymce_editor}
           />
         }
         {

--- a/src/react/containers/EntryContainer.js
+++ b/src/react/containers/EntryContainer.js
@@ -150,7 +150,7 @@ class EntryContainer extends Component {
                   <EditorContainer
                     entry={entry}
                     isEditing={true}
-                    backend={config.backend_liveblogging}
+                    use_tinymce_editor={config.use_tinymce_editor}
                   />
                 </div>
               )

--- a/src/react/containers/EntryContainer.js
+++ b/src/react/containers/EntryContainer.js
@@ -150,7 +150,7 @@ class EntryContainer extends Component {
                   <EditorContainer
                     entry={entry}
                     isEditing={true}
-                    use_tinymce_editor={config.use_tinymce_editor}
+                    usetinymce={config.usetinymce}
                   />
                 </div>
               )

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -64,6 +64,8 @@ export function createEntry(entry, config, nonce = false) {
     setTimeout(clearTinyMCEContent, 250);
   }
 
+  jQuery(document).trigger('liveblog-entry-created', [settings]);
+
   return secureAjax(settings);
 }
 
@@ -86,6 +88,8 @@ export function updateEntry(entry, config, nonce = false) {
     },
   };
 
+  jQuery(document).trigger('liveblog-entry-updated', [settings]);
+
   return secureAjax(settings);
 }
 
@@ -104,6 +108,8 @@ export function deleteEntry(id, config, nonce = false) {
       'cache-control': 'no-cache',
     },
   };
+
+  jQuery(document).trigger('liveblog-entry-deleted', [settings]);
 
   return secureAjax(settings);
 }

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -61,7 +61,7 @@ export function createEntry(entry, config, nonce = false) {
 
   // Clear TinyMCE after a brief delay.
   if (config.usetinymce === '1') {
-    setTimeout( clearTinyMCEContent, 250 );
+    setTimeout(clearTinyMCEContent, 250);
   }
 
   return secureAjax(settings);

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -47,7 +47,7 @@ export function createEntry(entry, config, nonce = false) {
     body: {
       crud_action: 'insert',
       post_id: config.post_id,
-      content: (config.use_tinymce_editor === '1') ? getTinyMCEContent() : entry.content,
+      content: (config.usetinymce === '1') ? getTinyMCEContent() : entry.content,
       author_id: entry.author,
       contributor_ids: entry.contributors,
     },
@@ -69,7 +69,7 @@ export function updateEntry(entry, config, nonce = false) {
       crud_action: 'update',
       post_id: config.post_id,
       entry_id: entry.id,
-      content: (config.use_tinymce_editor === '1') ? getTinyMCEContent() : entry.content,
+      content: (config.usetinymce === '1') ? getTinyMCEContent() : entry.content,
       author_id: entry.author,
       contributor_ids: entry.contributors,
     },

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -8,6 +8,10 @@ import {
   getCurrentTimestamp,
 } from '../utils/utils';
 
+import {
+  getTinyMCEContent,
+} from '../components/TinyMCEEditor';
+
 const getParams = x => `?${Object.keys(x).map(p => `&${p}=${x[p]}`).join('')}`;
 
 const secureAjax = (settings) => {
@@ -43,7 +47,7 @@ export function createEntry(entry, config, nonce = false) {
     body: {
       crud_action: 'insert',
       post_id: config.post_id,
-      content: entry.content,
+      content: (config.use_tinymce_editor === '1') ? getTinyMCEContent() : entry.content,
       author_id: entry.author,
       contributor_ids: entry.contributors,
     },
@@ -65,7 +69,7 @@ export function updateEntry(entry, config, nonce = false) {
       crud_action: 'update',
       post_id: config.post_id,
       entry_id: entry.id,
-      content: entry.content,
+      content: (config.use_tinymce_editor === '1') ? getTinyMCEContent() : entry.content,
       author_id: entry.author,
       contributor_ids: entry.contributors,
     },

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -10,6 +10,7 @@ import {
 
 import {
   getTinyMCEContent,
+  clearTinyMCEContent,
 } from '../components/TinyMCEEditor';
 
 const getParams = x => `?${Object.keys(x).map(p => `&${p}=${x[p]}`).join('')}`;
@@ -57,6 +58,11 @@ export function createEntry(entry, config, nonce = false) {
       'cache-control': 'no-cache',
     },
   };
+
+  // Clear TinyMCE after a brief delay.
+  if (config.usetinymce === '1') {
+    setTimeout( clearTinyMCEContent, 250 );
+  }
 
   return secureAjax(settings);
 }

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -1,3 +1,4 @@
+/* global jQuery */
 /**
  * RxJS ajax pretty much interchangable with axios.
  * Using RxJS ajax as it's already an observable to use with redux-observable.

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -12,6 +12,7 @@ import {
 import {
   getTinyMCEContent,
   clearTinyMCEContent,
+  clearAuthors,
 } from '../components/TinyMCEEditor';
 
 const getParams = x => `?${Object.keys(x).map(p => `&${p}=${x[p]}`).join('')}`;
@@ -62,7 +63,10 @@ export function createEntry(entry, config, nonce = false) {
 
   // Clear TinyMCE after a brief delay.
   if (config.usetinymce === '1') {
-    setTimeout(clearTinyMCEContent, 250);
+    setTimeout(() => {
+      clearTinyMCEContent();
+      clearAuthors();
+    }, 250);
   }
 
   jQuery(document).trigger('liveblog-entry-created', [settings]);


### PR DESCRIPTION
* add a new setting, return true from the `liveblog_use_tinymce_editor` filter to activate the tinymce editor (added in theme feature/liveblog branch)
* remove change listeners, we no longer need to sync editors with state, instead we alter data at last minute
* in api.js, use TinyMCE/Text area for content when making crud requests in tinymce active 
* fixes content processing induced issues including images