### PR TITLE
Add a headline for live updates

### DIFF
--- a/assets/dashboard/app.css
+++ b/assets/dashboard/app.css
@@ -88,3 +88,9 @@ body.wp-admin.liveblog.post-type-fte_liveblog #post_headline {
   margin-bottom: 10px;
   font-size: 16px;
 }
+
+body.wp-admin.liveblog.post-type-fte_liveblog #poststuff h2.liveblog-entry-header {
+  margin-left: 88px;
+  padding-left: 0;
+  font-size: 18px;
+}

--- a/assets/dashboard/app.css
+++ b/assets/dashboard/app.css
@@ -82,3 +82,9 @@ body.wp-admin.liveblog.post-type-fte_liveblog.wp-core-ui .button-primary#publish
 body.wp-admin .liveblog-editor-textarea {
   width: 100%;
 }
+
+body.wp-admin.liveblog.post-type-fte_liveblog #post_headline {
+  width: 100%;
+  margin-bottom: 10px;
+  font-size: 16px;
+}

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -139,13 +139,13 @@ class WPCOM_Liveblog_Entry {
 			'type'        => $this->get_type(),
 			'html'        => $this->render(),
 			'render'      => self::render_content( $this->get_content(), $this->comment ),
+			'headline'    => self::get_comment_headline_for_json( $entry_id ),
 			'content'     => apply_filters( 'liveblog_before_edit_entry', $this->get_content() ),
 			'css_classes' => $css_classes,
 			'timestamp'   => $this->get_timestamp(),
 			'authors'     => self::get_authors( $entry_id ),
 			'entry_time'  => $this->get_comment_date_gmt( 'U', $entry_id ),
 			'share_link'  => $share_link,
-			'headline'    => self::get_comment_headline_for_json( $entry_id ),
 		);
 		$entry = apply_filters( 'liveblog_entry_for_json', $entry, $this );
 		return (object) $entry;
@@ -161,6 +161,7 @@ class WPCOM_Liveblog_Entry {
 			'entry_id'               => $entry_id,
 			'post_id'                => $post_id,
 			'css_classes'            => $css_classes,
+			'headline'               => self::get_comment_headline_for_json( $entry_id ),
 			'content'                => self::render_content( $comment_text, $this->comment ),
 			'original_content'       => apply_filters( 'liveblog_before_edit_entry', $comment_text ),
 			'avatar_size'            => $avatar_size,
@@ -171,7 +172,6 @@ class WPCOM_Liveblog_Entry {
 			'timestamp'              => $this->get_timestamp(),
 			'is_liveblog_editable'   => WPCOM_Liveblog::is_liveblog_editable(),
 			'allowed_tags_for_entry' => self::$allowed_tags_for_entry,
-			'headline'               => self::get_comment_headline_for_json( $entry_id ),
 		);
 
 		return $entry;
@@ -226,8 +226,8 @@ class WPCOM_Liveblog_Entry {
 		}
 
 		// Add the headline as comment meta.
-		if ( isset( $args['header'] ) ) {
-			update_comment_meta( $comment->comment_ID, self::HEADLINE_META_KEY, sanitize_text_field( $args['contributor_ids'] ) );
+		if ( isset( $args['headline'] ) ) {
+			update_comment_meta( $comment->comment_ID, self::HEADLINE_META_KEY, sanitize_text_field( $args['headline'] ) );
 		}
 
 		if ( isset( $args['contributor_ids'] ) ) {
@@ -252,11 +252,6 @@ class WPCOM_Liveblog_Entry {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
 
-		// Add the headline as comment meta.
-		if ( isset( $args['header'] ) ) {
-			update_comment_meta( $comment->comment_ID, self::HEADLINE_META_KEY, sanitize_text_field( $args['contributor_ids'] ) );
-		}
-
 		// always use the original author for the update entry, otherwise until refresh
 		// users will see the user who editd the entry as  the author
 		$args['user'] = self::user_object_from_comment_id( $args['entry_id'] );
@@ -277,6 +272,12 @@ class WPCOM_Liveblog_Entry {
 		}
 		do_action( 'liveblog_update_entry', $comment->comment_ID, $args['post_id'] );
 		add_comment_meta( $comment->comment_ID, self::REPLACES_META_KEY, $args['entry_id'] );
+
+		// Add the headline as comment meta.
+		if ( isset( $args['header'] ) ) {
+			update_comment_meta( $comment->comment_ID, self::HEADLINE_META_KEY, sanitize_text_field( $args['contributor_ids'] ) );
+		}
+
 		wp_update_comment(
 			array(
 				'comment_ID'      => $args['entry_id'],
@@ -327,17 +328,19 @@ class WPCOM_Liveblog_Entry {
 		if ( is_wp_error( $valid_args ) ) {
 			return $valid_args;
 		}
+		error_log( json_encode( $args, JSON_PRETTY_PRINT ) );
+
 		$new_comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID'      => $args['post_id'],
 				'comment_content'      => $args['content'],
 				'comment_approved'     => 'liveblog',
 				'comment_type'         => 'liveblog',
-				'user_id'              => $args['user']->ID,
+				'user_id'              => isset( $args['user']->ID ) ? $args['user']->ID : '',
 
-				'comment_author'       => $args['user']->display_name,
-				'comment_author_email' => $args['user']->user_email,
-				'comment_author_url'   => $args['user']->user_url,
+				'comment_author'       => isset( $args['user']->display_name ) ? $args['user']->display_name : '',
+				'comment_author_email' => isset( $args['user']->user_email ) ? $args['user']->user_email : '',
+				'comment_author_url'   => isset( $args['user']->user_url ) ? $args['user']->user_url : '',
 			)
 		);
 		wp_cache_delete( 'liveblog_entries_asc_' . $args['post_id'], 'liveblog' );
@@ -429,10 +432,10 @@ class WPCOM_Liveblog_Entry {
 				wp_update_comment(
 					array(
 						'comment_ID'           => $entry_id,
-						'user_id'              => $args['user']->ID,
-						'comment_author'       => $args['user']->display_name,
-						'comment_author_email' => $args['user']->user_email,
-						'comment_author_url'   => $args['user']->user_url,
+						'user_id'              => isset( $args['user']->ID ) ? $args['user']->ID : '',
+						'comment_author'       => isset( $args['user']->display_name ) ? $args['user']->display_name : '',
+						'comment_author_email' => isset( $args['user']->user_email ) ? $args['user']->user_email : '',
+						'comment_author_url'   => isset( $args['user']->user_url ) ? $args['user']->user_url : '',
 					)
 				);
 
@@ -500,11 +503,9 @@ class WPCOM_Liveblog_Entry {
 	 */
 	private static function get_comment_headline_for_json( $comment_id ) {
 		$headline = get_comment_meta( $comment_id, self::HEADLINE_META_KEY, true );
-
 		if ( ! $headline ) {
 			return '';
 		}
-
 		return $headline;
 	}
 

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -274,8 +274,8 @@ class WPCOM_Liveblog_Entry {
 		add_comment_meta( $comment->comment_ID, self::REPLACES_META_KEY, $args['entry_id'] );
 
 		// Add the headline as comment meta.
-		if ( isset( $args['header'] ) ) {
-			update_comment_meta( $comment->comment_ID, self::HEADLINE_META_KEY, sanitize_text_field( $args['contributor_ids'] ) );
+		if ( isset( $args['headline'] ) ) {
+			update_comment_meta(  $args['entry_id'], self::HEADLINE_META_KEY, sanitize_text_field( $args['headline'] ) );
 		}
 
 		wp_update_comment(
@@ -328,7 +328,6 @@ class WPCOM_Liveblog_Entry {
 		if ( is_wp_error( $valid_args ) ) {
 			return $valid_args;
 		}
-		error_log( json_encode( $args, JSON_PRETTY_PRINT ) );
 
 		$new_comment_id = wp_insert_comment(
 			array(

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -374,6 +374,7 @@ class WPCOM_Liveblog_Rest_Api {
 			'entry_id'        => self::get_json_param( 'entry_id', $json ),
 			'author_id'       => self::get_json_param( 'author_id', $json ),
 			'contributor_ids' => self::get_json_param( 'contributor_ids', $json ),
+			'headline'        => self::get_json_param( 'headline', $json ),
 		);
 
 		// Add author to contributor list

--- a/src/react/Editor/Editor.js
+++ b/src/react/Editor/Editor.js
@@ -326,6 +326,7 @@ class EditorWrapper extends Component {
       usetinymce,
       editorContainer,
       clearAuthors,
+      clearHeadline,
     } = this.props;
 
     // Admin liveblogging uses TinyMCE.
@@ -334,6 +335,7 @@ class EditorWrapper extends Component {
         editorState={editorState}
         editorContainer={editorContainer}
         clearAuthors={clearAuthors}
+        clearHeadline={clearHeadline}
       />;
     }
 
@@ -405,6 +407,7 @@ EditorWrapper.propTypes = {
   usetinymce: PropTypes.string,
   editorContainer: PropTypes.object,
   clearAuthors: PropTypes.func,
+  clearHeadline: PropTypes.func,
 };
 
 export default EditorWrapper;

--- a/src/react/components/PostHeadline.js
+++ b/src/react/components/PostHeadline.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const PostHeadline = () => (
+  <div className="liveblog-post-headline">
+    <div className="liveblog-headline">
+      <label className="screen-reader-text" id="headline-prompt-text" htmlFor="headline">Enter update headline here</label>
+      <input
+        type="text"
+        name="post_headline"
+        size="80"
+        id="post_headline"
+        spellCheck="true"
+        autoComplete="off"
+        placeholder="Enter update headline..."
+      />
+    </div>
+  </div>
+);
+
+
+export default PostHeadline;

--- a/src/react/components/PostHeadline.js
+++ b/src/react/components/PostHeadline.js
@@ -1,21 +1,33 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const PostHeadline = () => (
-  <div className="liveblog-post-headline">
-    <div className="liveblog-headline">
-      <label className="screen-reader-text" id="headline-prompt-text" htmlFor="headline">Enter update headline here</label>
-      <input
-        type="text"
-        name="post_headline"
-        size="80"
-        id="post_headline"
-        spellCheck="true"
-        autoComplete="off"
-        placeholder="Enter update headline..."
-      />
-    </div>
-  </div>
-);
+class PostHeadline extends React.Component {
+  updateInputValue(evt) {
+    this.props.onChange(evt.target.value);
+  }
+  render() {
+    return (
+      <div className="liveblog-post-headline">
+        <div className="liveblog-headline">
+          <label className="screen-reader-text" id="headline-prompt-text" htmlFor="headline">Enter update headline here</label>
+          <input
+            type="text"
+            name="post_headline"
+            size="80"
+            id="post_headline"
+            spellCheck="true"
+            autoComplete="off"
+            placeholder="Enter update headline..."
+            onChange={evt => this.updateInputValue(evt)}
+          />
+        </div>
+      </div>
+    );
+  }
+}
 
+PostHeadline.propTypes = {
+  onChange: PropTypes.func,
+};
 
 export default PostHeadline;

--- a/src/react/components/PostHeadline.js
+++ b/src/react/components/PostHeadline.js
@@ -19,6 +19,7 @@ class PostHeadline extends React.Component {
             autoComplete="off"
             placeholder="Enter update headline..."
             onChange={evt => this.updateInputValue(evt)}
+            value={this.props.headline}
           />
         </div>
       </div>
@@ -28,6 +29,7 @@ class PostHeadline extends React.Component {
 
 PostHeadline.propTypes = {
   onChange: PropTypes.func,
+  headline: PropTypes.string,
 };
 
 export default PostHeadline;

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -47,7 +47,7 @@ class TinyMCEEditor extends Component {
           tinymce.activeEditor.setContent(stateContent);
         }
       }, 500);
-      const editor = wp.editor.initialize(this.containerId, this.editorSettings);
+      wp.editor.initialize(this.containerId, this.editorSettings);
     }, 1000);
   }
 

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -27,21 +27,27 @@ export const clearAuthors = () => {
   }
 };
 
+export const clearHeadline = () => {
+  if (tinymce.activeEditor.clearHeadline) {
+    tinymce.activeEditor.clearHeadline();
+  }
+};
 
 class TinyMCEEditor extends Component {
   constructor(props) {
     super(props);
     this.containerId = `live-editor-${Math.floor(Math.random() * 100000)}`;
     this.editorSettings = window.liveblog_settings.editorSettings;
-    setTimeout(() => {
-      setTimeout(() => {
+    setTimeout(() => { // wait for load
+      setTimeout(() => { // wait for editor init
         const stateContent = this.props.editorContainer.getContent();
         tinymce.activeEditor.clearAuthors = this.props.clearAuthors;
+        tinymce.activeEditor.clearHeadline = this.props.clearHeadline;
         if (stateContent && stateContent !== '' && stateContent !== '<p></p>') {
           tinymce.activeEditor.setContent(stateContent);
         }
       }, 500);
-      wp.editor.initialize(this.containerId, this.editorSettings);
+      const editor = wp.editor.initialize(this.containerId, this.editorSettings);
     }, 1000);
   }
 

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -53,6 +53,7 @@ class EditorContainer extends Component {
       authors: initialAuthors,
       mode: 'editor',
       readOnly: false,
+      headline: '',
       rawText: props.entry ? props.entry.content : '',
     };
 
@@ -63,6 +64,10 @@ class EditorContainer extends Component {
 
     this.clearAuthors = () => this.setState({
       authors: false,
+    });
+
+    this.clearHeadline = () => this.setState({
+      headline: '',
     });
   }
 
@@ -237,6 +242,7 @@ class EditorContainer extends Component {
       mode,
       authors,
       readOnly,
+      headline,
     } = this.state;
 
     const { isEditing, config, usetinymce } = this.props;
@@ -247,11 +253,13 @@ class EditorContainer extends Component {
         }
         return false;
       }) : [];
-
     return (
       <div className="liveblog-editor-container">
         {!isEditing && <h1 className="liveblog-editor-title">Add New Entry</h1>}
-        <PostHeadline onChange={this.onHeadlineChange.bind(this)} />
+        <PostHeadline
+          onChange={this.onHeadlineChange.bind(this)}
+          headline={headline}
+        />
         { (usetinymce !== '1') &&
           <div className="liveblog-editor-tabs">
             <button
@@ -297,6 +305,7 @@ class EditorContainer extends Component {
             defaultImageSize={config.default_image_size}
             usetinymce={config.usetinymce}
             clearAuthors={this.clearAuthors}
+            clearHeadline={this.clearHeadline}
           />
         }
         {

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -19,6 +19,7 @@ import { getAuthors, getHashtags, uploadImage } from '../services/api';
 import PreviewContainer from './PreviewContainer';
 import AuthorSelectOption from '../components/AuthorSelectOption';
 import HTMLInput from '../components/HTMLInput';
+import PostHeadline from '../components/PostHeadline';
 
 import Editor, { decorators, convertFromHTML, convertToHTML } from '../Editor/index';
 
@@ -241,6 +242,7 @@ class EditorContainer extends Component {
     return (
       <div className="liveblog-editor-container">
         {!isEditing && <h1 className="liveblog-editor-title">Add New Entry</h1>}
+        <PostHeadline />
         { (usetinymce !== '1') &&
           <div className="liveblog-editor-tabs">
             <button

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -53,7 +53,7 @@ class EditorContainer extends Component {
       authors: initialAuthors,
       mode: 'editor',
       readOnly: false,
-      headline: '',
+      headline: props.entry ? props.entry.headline : '',
       rawText: props.entry ? props.entry.content : '',
     };
 

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -99,6 +99,7 @@ class EditorContainer extends Component {
     const authorIds = authors.map(author => author.id);
     const author = authorIds.length > 0 ? authorIds[0] : false;
     const contributors = authorIds.length > 1 ? authorIds.slice(1, authorIds.length) : false;
+    const headline = this.state.headline;
 
     if (isEditing) {
       updateEntry({
@@ -106,6 +107,7 @@ class EditorContainer extends Component {
         content,
         author,
         contributors,
+        headline,
       });
       entryEditClose(entry.id);
       return;
@@ -115,6 +117,7 @@ class EditorContainer extends Component {
       content,
       author,
       contributors,
+      headline,
     });
 
     const newEditorState = EditorState.push(
@@ -129,6 +132,12 @@ class EditorContainer extends Component {
   onSelectAuthorChange(value) {
     this.setState({
       authors: value,
+    });
+  }
+
+  onHeadlineChange(value) {
+    this.setState({
+      headline: value,
     });
   }
 
@@ -242,7 +251,7 @@ class EditorContainer extends Component {
     return (
       <div className="liveblog-editor-container">
         {!isEditing && <h1 className="liveblog-editor-title">Add New Entry</h1>}
-        <PostHeadline />
+        <PostHeadline onChange={this.onHeadlineChange.bind(this)} />
         { (usetinymce !== '1') &&
           <div className="liveblog-editor-tabs">
             <button

--- a/src/react/containers/EntryContainer.js
+++ b/src/react/containers/EntryContainer.js
@@ -149,6 +149,11 @@ class EntryContainer extends Component {
               <abbr title={formattedTime(entry.entry_time, config.utc_offset, 'c')} className="liveblog-timestamp">{formattedTime(entry.entry_time, config.utc_offset, config.time_format)}</abbr>
             </a>
           </header>
+          { entry.headline &&
+            <h2 className="liveblog-entry-header">
+              {entry.headline}
+            </h2>
+          }
           {
             this.isEditing()
               ? (

--- a/src/react/containers/EntryContainer.js
+++ b/src/react/containers/EntryContainer.js
@@ -13,9 +13,9 @@ const authorLink = (author) => {
   let slug = '';
   if (typeof author !== 'undefined' && author && author.name) {
     slug = author.name.toLowerCase();
-    slug = slug.replace( /[^%a-z0-9 _-]/g, '' );
-    slug = slug.replace( /\s+/g, '-' );
-    slug = slug.replace( /-+/g, '-' );
+    slug = slug.replace(/[^%a-z0-9 _-]/g, '');
+    slug = slug.replace(/\s+/g, '-');
+    slug = slug.replace(/-+/g, '-');
 
     result = `/contributors/${slug}/`;
   }

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -88,6 +88,7 @@ export function updateEntry(entry, config, nonce = false) {
       content: (config.usetinymce === '1') ? getTinyMCEContent() : entry.content,
       author_id: entry.author,
       contributor_ids: entry.contributors,
+      headline: entry.headline,
     },
     headers: {
       'Content-Type': 'application/json',

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -13,6 +13,7 @@ import {
   getTinyMCEContent,
   clearTinyMCEContent,
   clearAuthors,
+  clearHeadline,
 } from '../components/TinyMCEEditor';
 
 const getParams = x => `?${Object.keys(x).map(p => `&${p}=${x[p]}`).join('')}`;
@@ -67,6 +68,7 @@ export function createEntry(entry, config, nonce = false) {
     setTimeout(() => {
       clearTinyMCEContent();
       clearAuthors();
+      clearHeadline();
     }, 250);
   }
 

--- a/src/react/services/api.js
+++ b/src/react/services/api.js
@@ -53,6 +53,7 @@ export function createEntry(entry, config, nonce = false) {
       content: (config.usetinymce === '1') ? getTinyMCEContent() : entry.content,
       author_id: entry.author,
       contributor_ids: entry.contributors,
+      headline: entry.headline,
     },
     headers: {
       'Content-Type': 'application/json',

--- a/templates/liveblog-single-entry.php
+++ b/templates/liveblog-single-entry.php
@@ -4,6 +4,11 @@
 		<span class="liveblog-author-name"><?php echo wp_kses_post( $author_link ); ?></span>
 		<span class="liveblog-meta-time"><a href="#liveblog-entry-<?php echo absint( $entry_id ); ?>" class="liveblog-time-update"><span class="date"><?php echo esc_html( $entry_date ); ?></span><span class="time"><?php echo esc_html( $entry_time ); ?></span></a></span>
 	</header>
+	<?php if ( $headline ) { ?>
+		<h2 class="liveblog-entry-header">
+			<?php echo wp_kses_post( $headline ); ?>
+		</h2>
+	<?php } ?>
 	<div class="liveblog-entry-text" data-original-content="<?php echo esc_attr( $original_content ); ?>">
 		<?php echo wp_kses_post( $content ); ?>
 	</div>


### PR DESCRIPTION
* Add a headline field above the TinyMCE editor, like LivePress.
* Headline field is optional.
* Store the headline in wp_commentmeta.
* Send the headline over JSON.
* Render the headline, if present, in EntryContainer.js
* php rendering for initial load
* Clear headline after posting from main/top editor
* Sync headline from data when using inline editor