### PR TITLE
Fix crash when editing entry with inline styles

### DIFF
--- a/src/react/Editor/Editor.js
+++ b/src/react/Editor/Editor.js
@@ -327,6 +327,7 @@ class EditorWrapper extends Component {
       editorContainer,
       clearAuthors,
       clearHeadline,
+      rawText,
     } = this.props;
 
     // Admin liveblogging uses TinyMCE.
@@ -336,6 +337,7 @@ class EditorWrapper extends Component {
         editorContainer={editorContainer}
         clearAuthors={clearAuthors}
         clearHeadline={clearHeadline}
+        rawText={rawText}
       />;
     }
 
@@ -408,6 +410,7 @@ EditorWrapper.propTypes = {
   editorContainer: PropTypes.object,
   clearAuthors: PropTypes.func,
   clearHeadline: PropTypes.func,
+  rawText: PropTypes.string,
 };
 
 export default EditorWrapper;

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -40,7 +40,7 @@ class TinyMCEEditor extends Component {
     this.editorSettings = window.liveblog_settings.editorSettings;
     setTimeout(() => { // wait for load
       setTimeout(() => { // wait for editor init
-        const stateContent = this.props.editorContainer.getContent();
+        const stateContent = this.props.rawText;
         tinymce.activeEditor.clearAuthors = this.props.clearAuthors;
         tinymce.activeEditor.clearHeadline = this.props.clearHeadline;
         if (stateContent && stateContent !== '' && stateContent !== '<p></p>') {

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -39,16 +39,15 @@ class TinyMCEEditor extends Component {
     this.containerId = `live-editor-${Math.floor(Math.random() * 100000)}`;
     this.editorSettings = window.liveblog_settings.editorSettings;
     setTimeout(() => { // wait for load
-      setTimeout(() => { // wait for editor init
-        const stateContent = this.props.rawText;
-        tinymce.activeEditor.clearAuthors = this.props.clearAuthors;
-        tinymce.activeEditor.clearHeadline = this.props.clearHeadline;
-        if (stateContent && stateContent !== '' && stateContent !== '<p></p>') {
-          tinymce.activeEditor.setContent(stateContent);
-        }
-      }, 500);
+      this.editorSettings.setup = function () { console.log('set up!'); };
       wp.editor.initialize(this.containerId, this.editorSettings);
-    }, 1000);
+      const stateContent = this.props.rawText;
+      tinymce.activeEditor.clearAuthors = this.props.clearAuthors;
+      tinymce.activeEditor.clearHeadline = this.props.clearHeadline;
+      if (stateContent && stateContent !== '' && stateContent !== '<p></p>') {
+        tinymce.activeEditor.setContent(stateContent);
+      }
+    }, 10);
   }
 
   render() {

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -306,6 +306,7 @@ class EditorContainer extends Component {
             usetinymce={usetinymce}
             clearAuthors={this.clearAuthors}
             clearHeadline={this.clearHeadline}
+            rawText={this.state.rawText}
           />
         }
         {


### PR DESCRIPTION
* Switch to using rawText from state instead of entry parsing.
* Remove delay when initializing editor - we no longer need to wait.