### PR TITLE
 Add a filter for liveblog_prefill_author_field

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -1077,6 +1077,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 
 						'use_rest_api'                 => intval( self::use_rest_api() ),
 						'endpoint_url'                 => self::get_entries_endpoint_url(),
+						'prefill_author_field'         => apply_filters( 'liveblog_prefill_author_field', true ),
 						'backend_liveblogging'         => apply_filters( 'liveblog_back_end_liveblogging', false ),
 						'usetinymce'                   => apply_filters( 'liveblog_use_tinymce_editor', false ),
 						'editorSettings'               => apply_filters( 'liveblog_tinymce_editor_settings', array(

--- a/src/react/components/TinyMCEEditor.js
+++ b/src/react/components/TinyMCEEditor.js
@@ -39,7 +39,6 @@ class TinyMCEEditor extends Component {
     this.containerId = `live-editor-${Math.floor(Math.random() * 100000)}`;
     this.editorSettings = window.liveblog_settings.editorSettings;
     setTimeout(() => { // wait for load
-      this.editorSettings.setup = function () { console.log('set up!'); };
       wp.editor.initialize(this.containerId, this.editorSettings);
       const stateContent = this.props.rawText;
       tinymce.activeEditor.clearAuthors = this.props.clearAuthors;

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -44,7 +44,7 @@ class EditorContainer extends Component {
       initialAuthors = props.entry.authors;
     } else {
       initialEditorState = EditorState.createEmpty(decorators);
-      initialAuthors = [props.config.current_user];
+      initialAuthors = (props.config.prefill_author_field === '1') ? [props.config.current_user] : [];
     }
 
     this.state = {


### PR DESCRIPTION
To skip prefilling the author field, return false from the filter:

`add_filter( 'liveblog_prefill_author_field', '__return_false' );` 