### PR TITLE
When TinyMCE enabled, use editorState.rawText for `getContent`

### DIFF
--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -79,6 +79,9 @@ class EditorContainer extends Component {
 
   getContent() {
     const { editorState } = this.state;
+    if ('1' === this.props.usetinymce) {
+      return editorState.rawText;
+    }
     return convertToHTML(editorState.getCurrentContent());
   }
 


### PR DESCRIPTION
* Fix an issue that would throw a fatal react error when styles were present in edited content