### PR TITLE
Filter out empty authors.

### DIFF
--- a/src/react/containers/EntryContainer.js
+++ b/src/react/containers/EntryContainer.js
@@ -108,6 +108,9 @@ class EntryContainer extends Component {
   render() {
     const { entry, config } = this.props;
 
+    // Filter out empty authors.
+    entry.authors = entry.authors.filter(author => (author.id !== null && author.name !== null && author.key !== ''));
+
     return (
       <article
         id={`id_${entry.id}`}


### PR DESCRIPTION
Fixes a display issue where the editor showed a blank author item when there was no author for an update.

Before:

![](https://cl.ly/0a3K0Y473w3R/Image%202018-06-01%20at%2010.47.02%20AM.png)

After:

![](https://cl.ly/3E2d0X1e1Q2M/Image%202018-06-01%20at%2010.49.52%20AM.png)