### PR TITLE
Cache rendered comment content to avoid double running shortcodes.

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -209,7 +209,6 @@ class WPCOM_Liveblog_Entry {
 				$wpcom_liveblog_entry_embed = new WPCOM_Liveblog_Entry_Embed();
 				$content                    = $wpcom_liveblog_entry_embed->autoembed( $content, $comment );
 			}
-
 			$content = do_shortcode( $content );
 		}
 


### PR DESCRIPTION
Screenshot:

![](https://cl.ly/023P1l3U2L3I/[6005a731d5e0dd7d051a22bcb45e91c6]_Image%202018-06-11%20at%204.16.44%20PM.png)
