### PR TITLE
Improve error handling in convertToHTML.js

### DIFF
--- a/src/react/Editor/convertToHTML.js
+++ b/src/react/Editor/convertToHTML.js
@@ -10,7 +10,11 @@ export default contentState =>
     blockToHTML: (block) => {
       if (block.type === 'atomic') {
         const currentBlock = contentState.getBlockForKey(block.key);
-        const entity = contentState.getEntity(currentBlock.getEntityAt(0));
+        const entityAtZero = currentBlock.getEntityAt(0);
+        if (!entityAtZero) {
+          return '<p />';
+        }
+        const entity = contentState.getEntity(entityAtZero);
         const type = entity.getType();
 
         if (type === 'image') {


### PR DESCRIPTION
* Fix an issue that would crash the browser when trying to edit a live post with a single line table, eg:

`<table><tbody><tr><td>1893</td></tr></tbody></table>`

Instead of throwing an error, we return an empty paragraph in place of the block that fails parsing.