### PR TITLE
Add PHP_EOL before oembed link not just after.

### DIFF
--- a/classes/slack/rest-api/class-liveblog-webhook-api.php
+++ b/classes/slack/rest-api/class-liveblog-webhook-api.php
@@ -274,7 +274,7 @@ class Liveblog_Webhook_API {
 					}
 				} elseif ( $is_oembed ) {
 					// append new line to oembeds so that you can have back to back embed links
-					$link = $match[1] . PHP_EOL;
+					$link = PHP_EOL . $match[1] . PHP_EOL;
 				}
 
 				return $link;


### PR DESCRIPTION
This will resolve issues whereas a twitter status is used inline and meant to be an oembed:
`A tweet! https://twitter.com/ABCPolitics/status/1180865471941201921`

Turns the result into:
```
A tweet! 
https://twitter.com/ABCPolitics/status/1180865471941201921

```
Without the newline before the link, the oembed fails to pick it up.
