### PR TITLE
Delete and publish entry updates for AMP view.

### DIFF
--- a/classes/class-liveblog-amp.php
+++ b/classes/class-liveblog-amp.php
@@ -237,15 +237,35 @@ class Liveblog_AMP {
 		} else {
 			$entries = Liveblog::get_entries_paged( $request->page, $request->last );
 			$request = self::set_request_last_from_entries( $entries, $request );
-			//Updated hidden entries to deleted
 
+			// Key entries by ID so they can be overwritten.
+			if ( ! empty ( $entries['entries'] ) ) {
+				$e = [];
+				foreach ( $entries['entries'] as $entry ) {
+					$e[ 'entry_' . $entry->id ] = $entry;
+				}
+				$entries['entries'] = $e;
+			}
+
+			//Updated hidden entries to deleted
 			$hidden_entries = Liveblog_Entry::get_hidden_entries( $post->ID, false );
 			if ( $hidden_entries ) {
 				foreach ( $hidden_entries as $entry ) {
 					if ( is_null( $entry->entry_time ) ) {
 						$entry->entry_time = $entry->timestamp;
 					}
-					$entries['entries'][] = $entry;
+					$entries['entries'][ 'entry_' . $entry->id ] = $entry;
+				}
+			}
+
+			$updated_entries = Liveblog_Entry::get_updated_entries( $post->ID, true );
+			if ( $updated_entries ) {
+				foreach ( $updated_entries as $entry ) {
+					if ( is_null( $entry->entry_time ) ) {
+						$entry->entry_time = $entry->timestamp;
+					}
+
+					$entries['entries'][ 'entry_' . $entry->id ] = $entry;
 				}
 			}
 


### PR DESCRIPTION
Resolves the following bug.
1. Enter text via WP post editor
2. Publish post
3. "Load New Post" button is triggered - click to show post
4. Unpublish/delete post via the queue
5. Post remains on the AMP view

This is done by accounting for 'updated_entries' cache. This does not, however, resolve the issue of Publish > Draft > Publish - once a published post is removed, it cannot be re-added to the view, a manual refresh is still required. This is due to the implementation method of amp-live-list.