### PR TITLE
Better cache/merge management for entries.

### DIFF
--- a/classes/class-liveblog-entry.php
+++ b/classes/class-liveblog-entry.php
@@ -583,6 +583,10 @@ class Liveblog_Entry {
 			unset( $hidden_entries[ $entry_post->ID ] );
 		}
 
+		if ( 'delete' === $status ) {
+			self::store_updated_entries( $entry_post, $liveblog_id, true );
+		}
+
 		wp_cache_set( $cached_key, array_filter( $hidden_entries ), 'liveblog', 30 ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.LowCacheTime
 	}
 
@@ -611,7 +615,7 @@ class Liveblog_Entry {
 				continue;
 			}
 
-			$entries[] = $entry;
+			$entries[ $entry_id ] = $entry;
 		}
 
 		return $entries;

--- a/classes/class-liveblog-entry.php
+++ b/classes/class-liveblog-entry.php
@@ -670,11 +670,11 @@ class Liveblog_Entry {
 			}
 
 			if ( ! empty( $selected_status ) && $selected_status === $entry->status ) {
-				$entries[] = $entry;
+				$entries[ $entry_id ] = $entry;
 			} elseif ( empty( $selected_status ) ) {
-				$entries[] = $entry;
+				$entries[ $entry_id ] = $entry;
 			} elseif ( ! empty( $selected_status ) && Liveblog::current_user_can_edit_liveblog() ) {
-				$entries[] = $entry;
+				$entries[ $entry_id ] = $entry;
 			}
 		}
 

--- a/classes/class-liveblog.php
+++ b/classes/class-liveblog.php
@@ -594,6 +594,10 @@ if ( ! class_exists( 'Liveblog' ) ) :
 				$entries_for_json = array_filter( array_replace( $entries_for_json, $updated_entries ) );
 			}
 
+			if ( ! empty( $entries_for_json ) ) {
+				$entries_for_json = array_values( $entries_for_json );
+			}
+
 			if ( ! empty( $entries ) ) {
 				// Get entry ids to used for removing existing entries from the list
 				$entry_ids = array_map( 'absint', wp_list_pluck( $entries_for_json, 'id' ) );

--- a/classes/class-liveblog.php
+++ b/classes/class-liveblog.php
@@ -577,21 +577,21 @@ if ( ! class_exists( 'Liveblog' ) ) :
 			 */
 			$hidden_entries = Liveblog_Entry::get_hidden_entries( self::$post_id, self::current_user_can_edit_liveblog() );
 			if ( ! empty( $hidden_entries ) ) {
-				$entries_for_json = array_filter( array_merge( $entries_for_json, $hidden_entries ) );
+				$entries_for_json = array_filter( array_replace( $entries_for_json, $hidden_entries ) );
 			}
 
 			// append locked entries to the response if they exist
 			if ( self::current_user_can_edit_liveblog() ) {
 				$locked_entries = Liveblog_Entry::get_locked_entries( self::$post_id );
 				if ( ! empty( $locked_entries ) ) {
-					$entries_for_json = array_filter( array_merge( $entries_for_json, $locked_entries ) );
+					$entries_for_json = array_filter( array_replace( $entries_for_json, $locked_entries ) );
 				}
 			}
 
 			// append updated entries to the response if they exist. This should only be called from the admin
 			$updated_entries = Liveblog_Entry::get_updated_entries( self::$post_id, ! self::current_user_can_edit_liveblog() );
 			if ( ! empty( $updated_entries ) ) {
-				$entries_for_json = array_filter( array_merge( $entries_for_json, $updated_entries ) );
+				$entries_for_json = array_filter( array_replace( $entries_for_json, $updated_entries ) );
 			}
 
 			if ( ! empty( $entries ) ) {


### PR DESCRIPTION
Keys entries by ID so they can be properly merged as well as switching to the use of array_replace()

```
/**
 * Array merges are unreliable for non-string keys.
 * If you need to merge with numeric keys, even if it's a string
 * use array_replace() instead.
 */

$x = []; // blank array

$y = [ 'one' => 'apple' ];
print_r( array_merge( $x, $y ) );
//     [one] => apple

$z = [ 123 => 'apple pie' ];
print_r( array_merge( $x, $z ) );
//     [0] => apple pie

$zz = [ '123' => 'sometest' ];
print_r( array_merge( $x, $zz ) );
//     [0] => sometest

// Array_merge is unreliable for numeric strings for keys, use array_replace instead.
print_r( array_replace( $x, $zz ) );
//     [123] => sometest
```

https://3v4l.org/ZR3sF - to test it out