### PR TITLE
Avoid namespace collision with multi-webpack runtimes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ const webpackConfig = {
     path: path.join(__dirname, paths.out),
     filename: '[name].js?v=[hash:6]',
     chunkFilename: '[name].bundle.js?v=[hash:6]',
+    jsonpFunction: 'wpJsonpLiveBlog',
   },
 
   module: {


### PR DESCRIPTION
See https://github.com/Automattic/liveblog/issues/661 https://github.com/Automattic/liveblog/pull/660/files